### PR TITLE
fix test skipping when '-x' argument is used

### DIFF
--- a/bin/run_cram_unit.py
+++ b/bin/run_cram_unit.py
@@ -34,7 +34,7 @@ def _get_parser():
     p.add_argument("--debug", action="store_true",
                    help='Turn on debug mode and log to stdout.')
 
-    p.add_argument('-x', dest='xunit_file', default="cram_xunit.xml",
+    p.add_argument('-x', "--xunit-file", dest='xunit_file', default="cram_xunit.xml",
                    help="Name of file to write Xunit.xml output to.")
 
     p.add_argument("--cram_prefix", default=None,

--- a/cram_unit/__init__.py
+++ b/cram_unit/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 8)
+VERSION = (0, 8, 1)
 
 
 def get_version():

--- a/cram_unit/crammer.py
+++ b/cram_unit/crammer.py
@@ -171,8 +171,9 @@ def _run_suite(suite, xunit_file):
            'NOSE_VERBOSE': 1}
 
     # Using itertools here is the magic that makes the Xunit plugins and
-    # the test cases to work as expected.
-    nx = nose.core.main(env=env, suite=itertools.chain(suite), exit=to_exit)
+    # the test cases to work as expected.  We need to santize argv as well
+    # to suppress the '-x' argument if it was used.
+    nx = nose.core.run(env=env, argv=["cram_unit", "--verbose"], suite=itertools.chain(suite))
 
     log.info("Nose output {o}".format(o=nx))
 


### PR DESCRIPTION
This conflicts with a nose argument :

```
  -x, --stop            Stop running tests after the first error or failure
```

and it was being propagated to nose.
